### PR TITLE
Adds ability to set the status on the redirect

### DIFF
--- a/README
+++ b/README
@@ -80,6 +80,11 @@ You are able to turn disable ssl redirects by adding the following environment c
 
     SslRequirement.disable_ssl_check = true
 
+You are able to the change the status code (defaults to 302) of the redirect by
+addng the following to the environment configuration file:
+
+  SslRequirement.redirect_status = :moved_permanently
+
 P.S.: Beware when you include the SslRequirement module. At the time of
 inclusion, it'll add the before_filter that validates the declarations. Some
 times you'll want to run other before_filters before that. They should then be

--- a/lib/ssl_requirement.rb
+++ b/lib/ssl_requirement.rb
@@ -21,7 +21,7 @@ require "#{File.dirname(__FILE__)}/url_for"
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 module SslRequirement
-  mattr_writer :ssl_host, :non_ssl_host, :disable_ssl_check
+  mattr_writer :ssl_host, :non_ssl_host, :disable_ssl_check, :redirect_status
 
   def self.ssl_host
     determine_host(@@ssl_host) rescue nil
@@ -96,13 +96,13 @@ module SslRequirement
     return true if SslRequirement.disable_ssl_check?
 
     if ssl_required? && !request.ssl?
-      redirect_to determine_redirect_url(request, true)
+      redirect_to determine_redirect_url(request, true), :status => (redirect_status || 302)
       flash.keep
       return false
     elsif request.ssl? && ssl_allowed?
       return true
     elsif request.ssl? && !ssl_required?
-      redirect_to determine_redirect_url(request, false)
+      redirect_to determine_redirect_url(request, false), :status => (redirect_status || 302)
       flash.keep
       return false
     end


### PR DESCRIPTION
Our marketing team wanted the redirects for SSL to be 301 instead of the default 302.  This commit adds another option so that the redirect status can be specified in the config.
