### PR TITLE
Refactor url generation

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,1 @@
-rvm use ruby-1.9.3-p0@ssl_requirement --create
+rvm use @ssl_requirement --create

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "http://rubygems.org"
 
-gem "actionpack", "~> 3.1.3"
+gem "actionpack", "~> 3.2.13"
 
 group :development do
-  gem "minitest-reporters", "~> 0.4"
+  gem "minitest-reporters", "~> 0.14"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,54 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    actionpack (3.2.13)
+      activemodel (= 3.2.13)
+      activesupport (= 3.2.13)
+      builder (~> 3.0.0)
+      erubis (~> 2.7.0)
+      journey (~> 1.0.4)
+      rack (~> 1.4.5)
+      rack-cache (~> 1.2)
+      rack-test (~> 0.6.1)
+      sprockets (~> 2.2.1)
+    activemodel (3.2.13)
+      activesupport (= 3.2.13)
+      builder (~> 3.0.0)
+    activesupport (3.2.13)
+      i18n (= 0.6.1)
+      multi_json (~> 1.0)
+    ansi (1.4.3)
+    builder (3.0.4)
+    erubis (2.7.0)
+    hashie (2.0.4)
+    hike (1.2.2)
+    i18n (0.6.1)
+    journey (1.0.4)
+    minitest (4.7.4)
+    minitest-reporters (0.14.18)
+      ansi
+      builder
+      minitest (>= 2.12, < 5.0)
+      powerbar
+    multi_json (1.7.3)
+    powerbar (1.0.11)
+      ansi (~> 1.4.0)
+      hashie (>= 1.1.0)
+    rack (1.4.5)
+    rack-cache (1.2)
+      rack (>= 0.4)
+    rack-test (0.6.2)
+      rack (>= 1.0)
+    sprockets (2.2.2)
+      hike (~> 1.2)
+      multi_json (~> 1.0)
+      rack (~> 1.0)
+      tilt (~> 1.1, != 1.3.0)
+    tilt (1.4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  actionpack (~> 3.2.13)
+  minitest-reporters (~> 0.14)

--- a/lib/ssl_requirement.rb
+++ b/lib/ssl_requirement.rb
@@ -169,7 +169,7 @@ module SslRequirement
   end
 
   def self.determine_host(host)
-    if host.is_a?(Proc) || host.respond_to?(:call)
+    if host.respond_to?(:call)
       host.call
     else
       host

--- a/lib/ssl_requirement.rb
+++ b/lib/ssl_requirement.rb
@@ -1,6 +1,8 @@
 require "#{File.dirname(__FILE__)}/url_for"
 require "active_support/core_ext/class"
 
+require "uri"
+
 # Copyright (c) 2005 David Heinemeier Hansson
 #
 # Permission is hereby granted, free of charge, to any person obtaining
@@ -113,10 +115,6 @@ module SslRequirement
     allowed_actions == [:all] || allowed_actions.include?(action_name.to_sym)
   end
 
-  # normal ports are the ports used when no port is specified by the user to the browser
-  # i.e. 80 if the protocol is http, 443 is the protocol is https
-  NORMAL_PORTS = [80, 443]
-
   private
   def ensure_proper_protocol
     return true if SslRequirement.disable_ssl_check?
@@ -135,37 +133,39 @@ module SslRequirement
   end
 
   def determine_redirect_url(request, ssl)
-    protocol = ssl ? "https" : "http"
-    "#{protocol}://#{determine_host_and_port(request, ssl)}#{request.fullpath}"
+    uri        = determine_base_uri(request.port, ssl)
+    uri.host ||= request.host
+    uri.path   = request.fullpath
+    uri.normalize!
+    uri.to_s
   end
 
-  def determine_host_and_port(request, ssl)
-    request_host = request.host
-    request_port = request.port
-
+  def determine_base_uri(request_port, ssl)
     if ssl
-      "#{ssl_host || request_host}#{determine_ssl_port_string request.port}"
+      host, port = ssl_host.to_s.split(":", 2)
+      port ||= determine_ssl_port_string(request_port)
+      URI::HTTPS.build(:host => host, :port => port.to_i)
     else
-      "#{non_ssl_host || request_host}#{determine_non_ssl_port_string request.port}"
+      host, port = non_ssl_host.to_s.split(":", 2)
+      port ||= determine_non_ssl_port_string(request_port)
+      URI::HTTP.build(:host => host, :port => port.to_i)
     end
   end
 
   def determine_ssl_port_string(request_port)
     if request_port == non_ssl_port
-      port = ssl_port
+      ssl_port
     else
-      port = request_port || ssl_port
+      request_port || ssl_port
     end
-    determine_port_string port
   end
 
   def determine_non_ssl_port_string(request_port)
     if request_port == ssl_port
-      port = non_ssl_port
+      non_ssl_port
     else
-      port = request_port || non_ssl_port
+      request_port || non_ssl_port
     end
-    determine_port_string port
   end
 
   def self.determine_host(host)
@@ -174,17 +174,5 @@ module SslRequirement
     else
       host
     end
-  end
-
-  def determine_port_string(port)
-    unless port_normal?(port)
-      ":#{port}"
-    else
-      ""
-    end
-  end
-
-  def port_normal?(port)
-    NORMAL_PORTS.include?(port)
   end
 end


### PR DESCRIPTION
This branch refactors the URL generation to use URI to construct the string, rather than using string concatenation directly.

It also cleans up a few small build issues I encountered while working with the gem in development.
