### PR TITLE
bugfix: ssl_allowed option is invalid bug

### DIFF
--- a/lib/ssl_requirement.rb
+++ b/lib/ssl_requirement.rb
@@ -90,7 +90,7 @@ module SslRequirement
     # ssl_allowed :all
     def ssl_allowed(*actions)
       self.ssl_allowed_actions ||= []
-      self.ssl_allowed_actions += actions
+      self.ssl_allowed_actions != [:all] && self.ssl_allowed_actions += actions
     end
   end
 


### PR DESCRIPTION
if "ssl_allowed :all" option is double defined
ssl_allowed function is invalid

for example...

```
class ApplicationController < ActionController::Base
 ssl_allowed :all
end

class PaymentController < ApplicationController
 ssl_allowed :all
end
```

payment controller cannot access https protocol.
