### PR TITLE
Make url_for_with_secure_option & url_for_with_non_ssl_host compatible

### DIFF
--- a/lib/url_for.rb
+++ b/lib/url_for.rb
@@ -6,7 +6,7 @@ module ActionDispatch
     class RouteSet
 
       # Add a secure option to the rewrite method.
-      def url_for_with_secure_option(options = {})
+      def url_for_with_secure_option(options = {}, *args)
         secure = options.delete(:secure)
 
         # if secure && ssl check is not disabled, convert to full url with https
@@ -30,18 +30,18 @@ module ActionDispatch
           end
         end
 
-        url_for_without_secure_option(options)
+        url_for_without_secure_option(options, *args)
       end
 
       # if full URL is requested for http and we've been told to use a
       # non-ssl host override, then use it
-      def url_for_with_non_ssl_host(options)
+      def url_for_with_non_ssl_host(options, *args)
         if !options[:only_path] && !SslRequirement.non_ssl_host.nil?
           if !(/^https/ =~ (options[:protocol] || @request.try(:protocol)))
             options.merge! :host => SslRequirement.non_ssl_host
           end
         end
-        url_for_without_non_ssl_host(options)
+        url_for_without_non_ssl_host(options, *args)
       end
 
       # want with_secure_option to get run first (so chain it last)


### PR DESCRIPTION
with Rails 4.2 ActionDispatch::Routing::RouteSet.

Arity of methods in ActionDispatch::Routing::RouteSet slightly changed. Now they are more liberal and accept more arguments as `*args`.

This change is compatible with Rails 3 & 4.
